### PR TITLE
Check provided teamIDs exist before creating/updating a user

### DIFF
--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -82,6 +82,22 @@ func (r *UserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, nil
 	}
 
+	// Check that the teamIDs exist before attempting to create the user
+	for _, teamID := range user.Spec.Teams {
+		_, err := r.GetTeam(ctx, teamID)
+		if err != nil {
+			if _, updateErr := r.updateConditions(ctx, user, metav1.Condition{
+				Type:    "Ready",
+				Status:  metav1.ConditionFalse,
+				Reason:  "TeamCheckFailed",
+				Message: err.Error(),
+			}); updateErr != nil {
+				log.Error(updateErr, "Failed to update conditions")
+			}
+			return ctrl.Result{}, nil
+		}
+	}
+
 	userID, err := r.GetUserID(ctx, user.Spec.UserEmail)
 	if err != nil {
 		log.Error(err, "Failed to check if User exists")

--- a/internal/controller/user_controller_test.go
+++ b/internal/controller/user_controller_test.go
@@ -59,6 +59,13 @@ func (l *FakeLitellmUserClient) GetUserID(ctx context.Context, userEmail string)
 	return "test-user-id", nil
 }
 
+func (l *FakeLitellmUserClient) GetTeam(ctx context.Context, teamID string) (litellm.TeamResponse, error) {
+	return litellm.TeamResponse{
+		TeamAlias: "test-team-alias",
+		TeamID:    teamID,
+	}, nil
+}
+
 func (l *FakeLitellmUserClient) IsUserUpdateNeeded(ctx context.Context, userResponse *litellm.UserResponse, userRequest *litellm.UserRequest) bool {
 	return false
 }

--- a/internal/litellm/litellm_team.go
+++ b/internal/litellm/litellm_team.go
@@ -170,7 +170,7 @@ func (l *LitellmClient) GetTeam(ctx context.Context, teamID string) (TeamRespons
 
 	body, err := l.makeRequest(ctx, "GET", "/team/info?team_id="+teamID, nil)
 	if err != nil {
-		log.Error(err, "Failed to get team")
+		log.Error(err, "Failed to get team with ID: "+teamID)
 		return TeamResponse{}, err
 	}
 

--- a/internal/litellm/litellm_user.go
+++ b/internal/litellm/litellm_user.go
@@ -14,6 +14,7 @@ type LitellmUser interface {
 	DeleteUser(ctx context.Context, userID string) error
 	GetUser(ctx context.Context, userID string) (UserResponse, error)
 	GetUserID(ctx context.Context, userEmail string) (string, error)
+	GetTeam(ctx context.Context, teamID string) (TeamResponse, error)
 	IsUserUpdateNeeded(ctx context.Context, user *UserResponse, req *UserRequest) bool
 	UpdateUser(ctx context.Context, req *UserRequest) (UserResponse, error)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

This PR fixes a reconcile loop when providing a non existent TeamID in a User spec