### PR TITLE
fix: clean up release workflow formatting and remove redundant push action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,9 +119,6 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-
-
-    
     - name: Install Helm
       uses: azure/setup-helm@v3
       with:
@@ -150,7 +147,6 @@ jobs:
         GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
         DOCKER_BUILDKIT: 1
 
-    
   update-manifests:
     needs: build-and-release
     runs-on: ubuntu-latest
@@ -167,6 +163,7 @@ jobs:
       with:
         app-id: ${{ secrets.LITELLM_OPERATOR_BOT_APP_ID }}
         private-key: ${{ secrets.LITELLM_OPERATOR_BOT_PRIVATE_KEY }}
+    
     - name: Install Helm
       uses: azure/setup-helm@v4
       with:
@@ -181,6 +178,7 @@ jobs:
   
     - uses: actions/checkout@v4
       with:
+        ref: main
         token: ${{ steps.github-app.outputs.token }}
 
     - name: Configure Git
@@ -198,8 +196,7 @@ jobs:
         cd config/manager
         kustomize edit set image controller=ghcr.io/${{ github.repository_owner }}/litellm-operator:$VERSION
         cd ../..
-        
-        
+
     - name: run helm generate
       run: |
         make helm-gen
@@ -211,7 +208,6 @@ jobs:
         echo "Changes made:"
         git diff --stat
 
-        
     - name: Commit changes
       run: |
         git add . 
@@ -221,14 +217,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ steps.github-app.outputs.token }}
 
-
-    - name: Push changes
-      uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ steps.github-app.outputs.token }}
-        branch: main
-  
-    
     - name: Extract version from Chart.yaml
       id: version
       run: |


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What does this PR do / why we need it**:

- Remove extra blank lines and whitespace throughout the workflow
- Add explicit 'ref: main' to checkout action as the subsequent push can't happen on a detached head
- Remove redundant 'Push changes' step that used ad-m/github-push-action