### PR TITLE
Docs workflow requires contents:write permission

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ env:
   PYTHON_VERSION: '3.11'
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

* Grants `contents:write` permission to the Documentation GitHub Actions workflow
