### PR TITLE
Docs had an invalid userRole

### DIFF
--- a/docs/api-reference/auth.litellm.ai.md
+++ b/docs/api-reference/auth.litellm.ai.md
@@ -380,7 +380,7 @@ _Appears in:_
 | `userAlias` _string_ | UserAlias is the alias of the user |  |  |
 | `userEmail` _string_ | UserEmail is the email of the user |  | Required: \{\} <br /> |
 | `userID` _string_ | UserID is the ID of the user. If not set, a unique ID will be generated. |  |  |
-| `userRole` _string_ | UserRole is the role of the user - one of "proxy_admin", "proxy_admin_viewer", "internal_user", "internal_user_viewer", "team", "customer" |  |  |
+| `userRole` _string_ | UserRole is the role of the user - one of "proxy_admin", "proxy_admin_viewer", "internal_user", "internal_user_viewer" |  |  |
 
 
 #### UserStatus

--- a/docs/user-guide/litellm-instances.md
+++ b/docs/user-guide/litellm-instances.md
@@ -354,7 +354,7 @@ metadata:
 spec:
   userEmail: "alice@example.com"
   userAlias: "alice"
-  userRole: "customer"
+  userRole: "internal_user_viewer"
   keyAlias: "alice-key"
   autoCreateKey: true
   models:

--- a/docs/user-guide/team-member-associations.md
+++ b/docs/user-guide/team-member-associations.md
@@ -131,7 +131,7 @@ metadata:
 spec:
   userEmail: "alice@example.com"
   userAlias: "alice"
-  userRole: "customer"
+  userRole: "internal_user_viewer"
   keyAlias: "alice-key"
   autoCreateKey: true
   models:

--- a/docs/user-guide/users.md
+++ b/docs/user-guide/users.md
@@ -24,7 +24,7 @@ metadata:
 spec:
   userEmail: "alice@example.com"
   userAlias: "alice"
-  userRole: "customer"
+  userRole: "internal_user_viewer"
   keyAlias: "alice-key"
   autoCreateKey: true
   models:
@@ -67,8 +67,8 @@ spec:
 |-------|------|-------------|----------|
 | `userEmail` | string | User's email address | Yes |
 | `userAlias` | string | User alias/username | Yes |
-| `userRole` | string | User role (customer, admin) | Yes |
-| `keyAlias` | string | Alias for the virtual key | Yes |
+| `userRole` | string | User role (one of "proxy_admin", "proxy_admin_viewer", "internal_user", "internal_user_viewer") | Yes |
+| `keyAlias` | string | Alias for the virtual key | No |
 | `autoCreateKey` | boolean | Automatically create virtual key | Yes |
 | `models` | []string | Allowed models for this user | No |
 | `maxBudget` | string | Maximum spend limit in dollars | Yes |
@@ -101,23 +101,8 @@ kubectl patch user alice --type='merge' -p='{"spec":{"maxBudget":"200"}}'
 kubectl delete user alice
 ```
 
-## User Roles
-
-### Customer User
-- Can create virtual keys
-- Limited to personal budget
-- Cannot manage other users
-- Access to specified models only
-
-### Admin User
-- Can manage all users and teams
-- Can create system-wide policies
-- Access to admin endpoints
-- Full model access
-
 ## Best Practices
 
-- Use email addresses as user identifiers for consistency
 - Set appropriate budget limits based on usage patterns
 - Use meaningful key aliases for easy identification
 - Enable autoCreateKey for seamless user onboarding


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What does this PR do / why we need it**:

Correct references to "customer" userRole. This is documented in the Litellm swagger but does not appear to actually be valid
