### PR TITLE
Message contained the string '$VERSION' rather than an interpolation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,7 +213,7 @@ jobs:
       id: commit-and-push
       uses: EndBug/add-and-commit@v9
       with:
-        message: "Automated update to $VERSION [skip ci]"
+        message: "Automated update to ${{ needs.build-and-release.outputs.validated_version }} [skip ci]"
         default_author: github_actions
         push: true
 


### PR DESCRIPTION
**What type of PR is this?**

/kind chore

**What does this PR do / why we need it**:

The helm chart update commit wasn't interpolating the $VERSION variable