### PR TITLE
Remove chart.lock with reference to cert-manager

### DIFF
--- a/deploy/charts/litellm-operator/Chart.lock
+++ b/deploy/charts/litellm-operator/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: cert-manager
-  repository: https://charts.jetstack.io
-  version: v1.18.2
-digest: sha256:2a56f8a97df98be8b753c21c74b86c0bca66607ce1488013febe5dd8650ee1a8
-generated: "2025-09-30T14:10:24.910868428+01:00"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What does this PR do / why we need it**:

Missed the chart.lock when clearing out cert-manager
