### PR TITLE
setup-go action default behaviour is to cache, explicit cache step wa…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,6 @@ jobs:
       with:
         go-version: '1.24'
 
-    - name: Cache Go modules
-      uses: actions/cache@v4
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
     - name: Download dependencies
       run: go mod download
 
@@ -153,7 +145,6 @@ jobs:
     - uses: actions/setup-go@v6
       with:
         go-version: '1.24'
-        cache: true
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,6 @@ jobs:
     - uses: actions/setup-go@v6
       with:
         go-version: '1.24'
-        cache: true
 
     - name: Run tests
       run: make test
@@ -102,7 +101,6 @@ jobs:
     - uses: actions/setup-go@v6
       with:
         go-version: '1.24'
-        cache: true
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
…s conflicting

**What type of PR is this?**

/kind chore

**What does this PR do / why we need it**:

Fixes errors that arise due to trying to cache go modules in 2 competing ways
