### PR TITLE
Bug: incorrect condition caused the reconciliation to continue when i…

### DIFF
--- a/internal/controller/model/model_controller.go
+++ b/internal/controller/model/model_controller.go
@@ -115,7 +115,7 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	var externalData ExternalData
 	// Phase 5: Ensure external resource (create/patch/repair drift)
-	if res, err := r.ensureExternal(ctx, model, &externalData); res.Requeue || err != nil {
+	if res, err := r.ensureExternal(ctx, model, &externalData); res.Requeue || res.RequeueAfter > 0 || err != nil {
 		r.InstrumentReconcileError()
 		return res, err
 	}

--- a/internal/controller/user/user_controller.go
+++ b/internal/controller/user/user_controller.go
@@ -116,7 +116,7 @@ func (r *UserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	var externalData ExternalData
 	// Phase 5: Ensure external resource (create/patch/repair drift)
-	if res, err := r.ensureExternal(ctx, user, &externalData); res.Requeue || err != nil {
+	if res, err := r.ensureExternal(ctx, user, &externalData); res.Requeue || res.RequeueAfter > 0 || err != nil {
 		r.InstrumentReconcileError()
 		return res, err
 	}


### PR DESCRIPTION
…t should have requeued

/kind bug

**What does this PR do / why we need it**:

The K8s secret containing the litellm key could sometimes be reset to an empty string. This was due to an incorrect condition check that caused the reconcile loop to continue with a blank ExternalData, rather than requeue