### PR TITLE
fix for user key getting reset to empty string after reconciliation

### DIFF
--- a/internal/controller/common/connection.go
+++ b/internal/controller/common/connection.go
@@ -216,7 +216,7 @@ func (h *LitellmConnectionHandler) getConnectionDetailsFromInstanceRef(ctx conte
 	if os.Getenv("LITELLM_URL_OVERRIDE") != "" {
 		url = os.Getenv("LITELLM_URL_OVERRIDE")
 	} else {
-		url = fmt.Sprintf("http://%s.%s.svc.cluster.local", service.Name, instanceNamespace)
+		url = fmt.Sprintf("http://%s.%s.svc.cluster.local:4000", service.Name, instanceNamespace)
 	}
 
 	return &ConnectionDetails{

--- a/internal/controller/litellm/litellminstance_controller.go
+++ b/internal/controller/litellm/litellminstance_controller.go
@@ -84,7 +84,7 @@ func init() {
 const (
 	// Container configuration constants
 	ContainerPort = 4000                                    // Port that the LiteLLM container listens on
-	ServicePort   = 80                                      // Port that the Service exposes
+	ServicePort   = 4000                                    // Port that the Service exposes
 	ConfigPath    = "/etc/litellm/proxy_server_config.yaml" // Path to config file in container
 
 	// Health check paths for container probes

--- a/internal/controller/user/user_controller.go
+++ b/internal/controller/user/user_controller.go
@@ -271,6 +271,10 @@ func (r *UserReconciler) ensureExternal(ctx context.Context, user *authv1alpha1.
 		}
 		log.Info("Successfully repaired drift in LiteLLM", "userID", user.Status.UserID)
 	} else {
+		externalData.Key = observedUser.Key
+		externalData.UserEmail = observedUser.UserEmail
+		externalData.UserRole = observedUser.UserRole
+		externalData.UserID = observedUser.UserID
 		log.V(1).Info("User is up to date in LiteLLM", "userID", user.Status.UserID)
 	}
 
@@ -279,7 +283,8 @@ func (r *UserReconciler) ensureExternal(ctx context.Context, user *authv1alpha1.
 
 // ensureChildren manages in-cluster child resources using CreateOrUpdate pattern
 func (r *UserReconciler) ensureChildren(ctx context.Context, user *authv1alpha1.User, externalData *ExternalData) error {
-	if user.Status.KeySecretRef == "" {
+	// the VirtualKey is never shown again after the User is created, so prevent the secret from being reset to an empty string
+	if user.Status.KeySecretRef == "" || externalData.Key == "" {
 		return nil // No secret to create
 	}
 

--- a/scripts/local-dev/Makefile
+++ b/scripts/local-dev/Makefile
@@ -40,8 +40,8 @@ deploy-manifests-dev: manifests kustomize
 	$(KUBECTL) wait --for=condition=Ready --timeout=120s -n litellm pod -l cnpg.io/instanceName=litellm-postgres-1,cnpg.io/instanceRole=primary
 
 
-.PHONY: dev-cluster-bootstrap
-dev-cluster-bootstrap-debug: kind-cluster install install-samples  deploy-manifests-dev install-samples  
+.PHONY: dev-cluster-bootstrap-debug
+dev-cluster-bootstrap-debug: kind-cluster install deploy-manifests-dev install-samples
 
 .PHONY: dev-cluster-bootstrap-full
 dev-cluster-bootstrap-full: IMG=controller:dev
@@ -51,7 +51,7 @@ dev-cluster-bootstrap-full: kind-cluster docker-build docker-load install deploy
 dev-cluster-bootstrap-full-recreate: kind-cluster-delete dev-cluster-bootstrap-full ## Recreate the Kind cluster and bootstrap
 
 .PHONY: dev-cluster-bootstrap-debug-recreate
-dev-cluster-bootstrap-debug-recreate: kind-cluster-delete dev-cluster-bootstrap-debug ## Recreate the Kind cluster and bootstrap
+dev-cluster-bootstrap-debug-recreate: kind-cluster-delete dev-cluster-bootstrap-debug ## Recreate the Kind cluster and bootstrap without the litellm-operator
 
 dev-port-forward-litellm:
-	$(KUBECTL) port-forward svc/litellm-example-service 8000:80 -n litellm > /dev/null 2>&1 &
+	$(KUBECTL) port-forward svc/litellm-example-service 4000:4000 -n litellm > /dev/null 2>&1 &


### PR DESCRIPTION
/kind bug

**What does this PR do / why we need it**:

fixes issue with a K8s Secret containing a User key getting reset to an empty string. Additionally there are some minor changes to make local debugging easier