### PR TITLE
fix: prevent VirtualKey secret getting reset to empty string after reconciliation

### DIFF
--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -122,6 +122,7 @@ changelog:
       - "^test:"
       - "^chore:"
       - "^ci:"
+      - "^Automated update to"
   groups:
     - title: Features
       regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -117,6 +117,7 @@ changelog:
       - "^test:"
       - "^chore:"
       - "^ci:"
+      - "^Automated update to"
   groups:
     - title: Features
       regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'

--- a/internal/controller/association/teammemberassociation_controller.go
+++ b/internal/controller/association/teammemberassociation_controller.go
@@ -143,7 +143,7 @@ func (r *TeamMemberAssociationReconciler) Reconcile(ctx context.Context, req ctr
 
 	var externalData ExternalData
 	// Phase 5: Ensure external resource (create/patch/repair drift)
-	if res, err := r.ensureExternal(ctx, teamMemberAssociation, &externalData); res.Requeue || res.RequeueAfter > 0 || err != nil {
+	if res, err := r.ensureExternal(ctx, teamMemberAssociation, &externalData); res.RequeueAfter > 0 || err != nil {
 		r.InstrumentReconcileError()
 		return res, err
 	}

--- a/internal/controller/team/team_controller.go
+++ b/internal/controller/team/team_controller.go
@@ -108,7 +108,7 @@ func (r *TeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	var externalData ExternalData
 	// Phase 5: Ensure external resource (create/patch/repair drift)
-	if res, err := r.ensureExternal(ctx, team, &externalData); res.Requeue || res.RequeueAfter > 0 || err != nil {
+	if res, err := r.ensureExternal(ctx, team, &externalData); res.RequeueAfter > 0 || err != nil {
 		r.InstrumentReconcileError()
 		return res, err
 	}

--- a/internal/controller/user/user_controller.go
+++ b/internal/controller/user/user_controller.go
@@ -116,7 +116,7 @@ func (r *UserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	var externalData ExternalData
 	// Phase 5: Ensure external resource (create/patch/repair drift)
-	if res, err := r.ensureExternal(ctx, user, &externalData); res.Requeue || res.RequeueAfter > 0 || err != nil {
+	if res, err := r.ensureExternal(ctx, user, &externalData); res.RequeueAfter > 0 || err != nil {
 		r.InstrumentReconcileError()
 		return res, err
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

fixes issue with a K8s Secret containing a VirtualKey getting reset to an empty string. Also removes some deprecations