### PR TITLE
fix: metadata in virtual keys

### DIFF
--- a/internal/litellm/litellm_virtualkey.go
+++ b/internal/litellm/litellm_virtualkey.go
@@ -70,6 +70,7 @@ type VirtualKeyResponse struct {
 	LiteLLMBudgetTable   string            `json:"litellm_budget_table,omitempty"`
 	MaxBudget            float64           `json:"max_budget,omitempty"`
 	MaxParallelRequests  int               `json:"max_parallel_requests,omitempty"`
+	Metadata             map[string]any    `json:"metadata,omitempty"`
 	// These don't actually come back here, they are injected into the metadata field which complicates things, so skip for now
 	// ModelMaxBudget       map[string]string `json:"model_max_budget,omitempty"`
 	// ModelRPMLimit        map[string]int    `json:"model_rpm_limit,omitempty"`
@@ -251,6 +252,10 @@ func (l *LitellmClient) IsVirtualKeyUpdateNeeded(ctx context.Context, virtualKey
 	}
 	if virtualKey.MaxParallelRequests != req.MaxParallelRequests {
 		log.Info("MaxParallelRequests changed")
+		return true
+	}
+	if !cmp.Equal(virtualKey.Metadata, req.Metadata, cmpopts.EquateEmpty()) {
+		log.Info("Metadata changed")
 		return true
 	}
 	if !cmp.Equal(virtualKey.Models, req.Models, cmpopts.EquateEmpty()) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

The `VirtualKey.Spec.Metadata` field was ignored. Now it is included in the reconcile.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

LiteLLM supports arbitrary nested objects in metadata, but `VirtualKey.Spec.Metadata` only supports `map[string]string`. The CRD could be improved to better match LiteLLM.