### PR TITLE
chore: update CI to use go 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ permissions:
   packages: read
   security-events: write
 
+env:
+  GO_VERSION: '1.25'
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -44,7 +47,7 @@ jobs:
 
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: ${{ env.GO_VERSION }}
 
     - name: Download dependencies
       run: go mod download
@@ -70,7 +73,7 @@ jobs:
 
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: ${{ env.GO_VERSION }}
 
     - name: Build operator
       run: make build
@@ -83,7 +86,7 @@ jobs:
 
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: ${{ env.GO_VERSION }}
 
     - name: Set up Kind cluster
       uses: helm/kind-action@v1
@@ -144,7 +147,7 @@ jobs:
 
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: ${{ env.GO_VERSION }}
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ permissions:
   id-token: write
   pull-requests: write
 
+env:
+  GO_VERSION: '1.25'
+
 jobs:
   run-tests:
     runs-on: ubuntu-latest
@@ -31,7 +34,7 @@ jobs:
 
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: ${{ env.GO_VERSION }}
 
     - name: Run tests
       run: make test
@@ -100,7 +103,7 @@ jobs:
 
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: ${{ env.GO_VERSION }}
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
**What type of PR is this?**

/kind chore

**What does this PR do / why we need it**:

Update CI to use go 1.25 as some dependabot updates require it
