### PR TITLE
chore: prevent chore and PR merge commits from showing up in the changelog

### DIFF
--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -120,9 +120,10 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
-      - "^chore:"
+      - "^chore(\([[:word:]]+\))?:"
       - "^ci:"
       - "^Automated update to"
+      - "^Merge pull request #"
   groups:
     - title: Features
       regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -115,9 +115,10 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
-      - "^chore:"
+      - "^chore(\([[:word:]]+\))?:"
       - "^ci:"
       - "^Automated update to"
+      - "^Merge pull request #"
   groups:
     - title: Features
       regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'


### PR DESCRIPTION
**What type of PR is this?**

/kind chore -->

**What does this PR do / why we need it**:

The changelog generated by goreleaser contains the PR merge commits, which isn't really desirable as it duplicates the commits that are in the changelog anyway. Also update chore filter to catch `chore(deps):` ie dependabot updates