### PR TITLE
fix: ensure extra environment variables are appended correctly

### DIFF
--- a/internal/controller/litellm/litellminstance_controller.go
+++ b/internal/controller/litellm/litellminstance_controller.go
@@ -1370,8 +1370,6 @@ func buildEnvironmentVariables(llm *litellmv1alpha1.LiteLLMInstance, secretName 
 		}
 		envVars = append(envVars, dbEnvVars...)
 
-		// Add extra environment variables
-		envVars = append(envVars, llm.Spec.ExtraEnvVars...)
 	}
 
 	for _, model := range llm.Spec.Models {
@@ -1409,6 +1407,9 @@ func buildEnvironmentVariables(llm *litellmv1alpha1.LiteLLMInstance, secretName 
 			})
 		}
 	}
+
+	// Add extra environment variables
+	envVars = append(envVars, llm.Spec.ExtraEnvVars...)
 
 	return envVars
 }


### PR DESCRIPTION
**What type of PR is this?**
This pull request updates how extra environment variables are added in the `buildEnvironmentVariables` function. The change ensures that all extra environment variables from `llm.Spec.ExtraEnvVars` are appended only once, after processing all other environment variables, rather than inside a conditional block.

- Environment variable handling:
  * Moved the appending of `llm.Spec.ExtraEnvVars` to the end of the `buildEnvironmentVariables` function, ensuring extra environment variables are always included after all other variables are processed. [[1]](diffhunk://#diff-d2a421c8a67769ddd6e8b5a0c78fa9c920e423039de27ec2cc2ac64574310da7L1373-L1374) [[2]](diffhunk://#diff-d2a421c8a67769ddd6e8b5a0c78fa9c920e423039de27ec2cc2ac64574310da7R1411-R1413)

/kind bug 

**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #164 
