### PR TITLE
feat: harden TeamMemberAssociation

### DIFF
--- a/api/auth/v1alpha1/teammemberassociation_types.go
+++ b/api/auth/v1alpha1/teammemberassociation_types.go
@@ -41,10 +41,12 @@ type TeamMemberAssociationSpec struct {
 
 	// TeamRef is a reference to the team
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="TeamRef is immutable"
 	TeamRef CRDRef `json:"teamRef,omitempty"`
 
 	// UserRef is a reference to the user
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="UserRef is immutable"
 	UserRef CRDRef `json:"userRef,omitempty"`
 }
 
@@ -66,6 +68,8 @@ type TeamMemberAssociationStatus struct {
 	UserEmail string `json:"userEmail,omitempty"`
 	// UserID is the ID of the user
 	UserID string `json:"userID,omitempty"`
+	// Role is the role of the user in the team
+	Role string `json:"role,omitempty"`
 
 	TeamExists         bool `json:"teamExists,omitempty"`
 	UserExists         bool `json:"userExists,omitempty"`

--- a/config/crd/bases/auth.litellm.ai_teammemberassociations.yaml
+++ b/config/crd/bases/auth.litellm.ai_teammemberassociations.yaml
@@ -127,6 +127,9 @@ spec:
                   namespace:
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: TeamRef is immutable
+                  rule: self == oldSelf
               userRef:
                 description: UserRef is a reference to the user
                 properties:
@@ -135,6 +138,9 @@ spec:
                   namespace:
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: UserRef is immutable
+                  rule: self == oldSelf
             required:
             - connectionRef
             - role
@@ -203,6 +209,9 @@ spec:
                   - type
                   type: object
                 type: array
+              role:
+                description: Role is the role of the user in the team
+                type: string
               teamAlias:
                 description: TeamAlias is the alias of the team
                 type: string

--- a/docs/api-reference/auth.litellm.ai.md
+++ b/docs/api-reference/auth.litellm.ai.md
@@ -229,6 +229,7 @@ _Appears in:_
 | `teamID` _string_ | TeamID is the ID of the team |  |  |
 | `userEmail` _string_ | UserEmail is the email of the user |  |  |
 | `userID` _string_ | UserID is the ID of the user |  |  |
+| `role` _string_ | Role is the role of the user in the team |  |  |
 | `teamExists` _boolean_ |  |  |  |
 | `userExists` _boolean_ |  |  |  |
 | `associationIsValid` _boolean_ |  |  |  |

--- a/internal/controller/association/teammemberassociation_controller.go
+++ b/internal/controller/association/teammemberassociation_controller.go
@@ -61,6 +61,7 @@ type ExternalData struct {
 	TeamID    string `json:"teamID"`
 	UserEmail string `json:"userEmail"`
 	UserID    string `json:"userID"`
+	Role      string `json:"role"`
 }
 
 // +kubebuilder:rbac:groups=auth.litellm.ai,resources=teammemberassociations,verbs=get;list;watch;create;update;patch;delete
@@ -297,6 +298,13 @@ func (r *TeamMemberAssociationReconciler) ensureExternal(ctx context.Context, te
 	externalData.TeamID = createResponse.TeamID
 	externalData.UserEmail = createResponse.UserEmail
 	externalData.UserID = createResponse.UserID
+	// Find role from members with role
+	for _, member := range createResponse.MembersWithRole {
+		if member.UserID == createResponse.UserID {
+			externalData.Role = member.Role
+			break
+		}
+	}
 
 	r.updateTeamMemberAssociationStatus(teamMemberAssociation, externalData)
 	if err := r.PatchStatus(ctx, teamMemberAssociation); err != nil {
@@ -398,6 +406,7 @@ func (r *TeamMemberAssociationReconciler) updateTeamMemberAssociationStatus(team
 	teamMemberAssociation.Status.TeamID = externalData.TeamID
 	teamMemberAssociation.Status.UserEmail = externalData.UserEmail
 	teamMemberAssociation.Status.UserID = externalData.UserID
+	teamMemberAssociation.Status.Role = externalData.Role
 }
 
 func (r *TeamMemberAssociationReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/controller/association/teammemberassociation_controller_test.go
+++ b/internal/controller/association/teammemberassociation_controller_test.go
@@ -409,24 +409,58 @@ var _ = Describe("TeamMemberAssociation Controller", func() {
 			err = reconciler.Create(context.Background(), readyUser)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Update association to reference existing but not-ready team
-			updatedAssociation := &authv1alpha1.TeamMemberAssociation{}
-			err = reconciler.Get(context.Background(), types.NamespacedName{
-				Name:      association.Name,
-				Namespace: association.Namespace,
-			}, updatedAssociation)
-			Expect(err).NotTo(HaveOccurred())
+			// Create a new association that references the not-ready team and ready user
+			// (TeamRef and UserRef are immutable, so we cannot update them on an existing resource)
+			notReadyAssociation := &authv1alpha1.TeamMemberAssociation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "not-ready-team-association",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: authv1alpha1.TeamMemberAssociationSpec{
+					Role: "user",
+					TeamRef: authv1alpha1.CRDRef{
+						Name:      "not-ready-team",
+						Namespace: "default",
+					},
+					UserRef: authv1alpha1.CRDRef{
+						Name:      "ready-user",
+						Namespace: "default",
+					},
+					ConnectionRef: authv1alpha1.ConnectionRef{
+						SecretRef: &authv1alpha1.SecretRef{
+							Name: "test-secret",
+							Keys: authv1alpha1.SecretKeys{
+								MasterKey: "masterkey",
+								URL:       "url",
+							},
+						},
+					},
+				},
+			}
 
-			updatedAssociation.Spec.TeamRef.Name = "not-ready-team"
-			updatedAssociation.Spec.UserRef.Name = "ready-user"
-			err = reconciler.Update(context.Background(), updatedAssociation)
+			// Create connection secret for the new association
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"masterkey": []byte("test-key"),
+					"url":       []byte("http://test-url"),
+				},
+			}
+			// Ignore error in case secret already exists from earlier test setup
+			_ = reconciler.Create(context.Background(), secret)
+
+			err = reconciler.Create(context.Background(), notReadyAssociation)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Reconcile should detect not-ready team
 			result, err = reconciler.Reconcile(context.Background(), ctrl.Request{
 				NamespacedName: types.NamespacedName{
-					Name:      association.Name,
-					Namespace: association.Namespace,
+					Name:      notReadyAssociation.Name,
+					Namespace: notReadyAssociation.Namespace,
 				},
 			})
 

--- a/internal/litellm/litellm_team_member_association.go
+++ b/internal/litellm/litellm_team_member_association.go
@@ -23,10 +23,11 @@ type TeamMemberAssociationRequest struct {
 }
 
 type TeamMemberAssociationResponse struct {
-	TeamAlias string `json:"team_alias,omitempty"`
-	TeamID    string `json:"team_id,omitempty"`
-	UserEmail string `json:"user_email,omitempty"`
-	UserID    string `json:"user_id,omitempty"`
+	TeamAlias       string               `json:"team_alias,omitempty"`
+	TeamID          string               `json:"team_id,omitempty"`
+	UserEmail       string               `json:"user_email,omitempty"`
+	UserID          string               `json:"user_id,omitempty"`
+	MembersWithRole []TeamMemberWithRole `json:"members_with_roles,omitempty"`
 }
 
 // CreateTeamMemberAssociation adds a User to a Team in the Litellm service

--- a/test/e2e/integration_e2e_test.go
+++ b/test/e2e/integration_e2e_test.go
@@ -277,7 +277,7 @@ var _ = Describe("Integration E2E Tests", Ordered, func() {
 			associationCR := createTeamMemberAssociationCR(associationCRName, teamCRName, userCRName)
 			Expect(k8sClient.Create(context.Background(), associationCR)).To(Succeed())
 
-			By("trying to update immutable teamAlias field")
+			By("trying to update immutable teamRef.Name field")
 			updatedAssociationCR := &authv1alpha1.TeamMemberAssociation{}
 			Expect(k8sClient.Get(context.Background(), types.NamespacedName{
 				Name:      associationCRName,


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:

TeamMemberAssociation is a logical connection between a User and a Team. The design means that reconciling changes to a User or Team ref is actually very brittle so make those fields immutable.

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**How to test changes / Special notes to the reviewer**:

This is an API change so will leave in draft until we plan a v2 release