### PR TITLE
feat: models field — omit = all models, empty list = no model access

### DIFF
--- a/api/auth/v1alpha1/user_types.go
+++ b/api/auth/v1alpha1/user_types.go
@@ -59,7 +59,7 @@ type UserSpec struct {
 	ModelRPMLimit map[string]string `json:"modelRPMLimit,omitempty"`
 	// ModelTPMLimit is the model specific maximum tokens per minute
 	ModelTPMLimit map[string]string `json:"modelTPMLimit,omitempty"`
-	// Models is the list of models that the user is allowed to use
+	// Models the user is allowed to use. Omit to allow all models; use empty list for no model access.
 	Models []string `json:"models,omitempty"`
 	// Permissions is the user-specific permissions
 	Permissions map[string]string `json:"permissions,omitempty"`
@@ -139,7 +139,7 @@ type UserStatus struct {
 	ModelRPMLimit map[string]string `json:"modelRPMLimit,omitempty"`
 	// ModelTPMLimit is the model specific maximum tokens per minute
 	ModelTPMLimit map[string]string `json:"modelTPMLimit,omitempty"`
-	// Models is the list of models that the user is allowed to use
+	// Models the user is allowed to use. Omit to allow all models; use empty list for no model access.
 	Models []string `json:"models,omitempty"`
 	// Permissions is the user-specific permissions
 	Permissions map[string]string `json:"permissions,omitempty"`

--- a/api/auth/v1alpha1/virtualkey_types.go
+++ b/api/auth/v1alpha1/virtualkey_types.go
@@ -67,7 +67,7 @@ type VirtualKeySpec struct {
 	ModelRPMLimit map[string]int `json:"modelRPMLimit,omitempty"`
 	// ModelTPMLimit sets TPM limits per model
 	ModelTPMLimit map[string]int `json:"modelTPMLimit,omitempty"`
-	// Models specifies which models can be used
+	// Models specifies which models can be used. Omit to allow all models; use empty list for no model access.
 	Models []string `json:"models,omitempty"`
 	// Permissions defines key permissions
 	Permissions map[string]string `json:"permissions,omitempty"`
@@ -133,7 +133,7 @@ type VirtualKeyStatus struct {
 	MaxBudget string `json:"maxBudget,omitempty"`
 	// MaxParallelRequests limits concurrent requests
 	MaxParallelRequests int `json:"maxParallelRequests,omitempty"`
-	// Models specifies which models can be used
+	// Models specifies which models can be used. Omit to allow all models; use empty list for no model access.
 	Models []string `json:"models,omitempty"`
 	// Permissions defines key permissions
 	Permissions map[string]string `json:"permissions,omitempty"`

--- a/config/crd/bases/auth.litellm.ai_users.yaml
+++ b/config/crd/bases/auth.litellm.ai_users.yaml
@@ -179,8 +179,8 @@ spec:
                   minute
                 type: object
               models:
-                description: Models is the list of models that the user is allowed
-                  to use
+                description: Models the user is allowed to use. Omit to allow all
+                  models; use empty list for no model access.
                 items:
                   type: string
                 type: array
@@ -393,8 +393,8 @@ spec:
                   minute
                 type: object
               models:
-                description: Models is the list of models that the user is allowed
-                  to use
+                description: Models the user is allowed to use. Omit to allow all
+                  models; use empty list for no model access.
                 items:
                   type: string
                 type: array

--- a/config/crd/bases/auth.litellm.ai_virtualkeys.yaml
+++ b/config/crd/bases/auth.litellm.ai_virtualkeys.yaml
@@ -191,7 +191,8 @@ spec:
                 description: ModelTPMLimit sets TPM limits per model
                 type: object
               models:
-                description: Models specifies which models can be used
+                description: Models specifies which models can be used. Omit to allow
+                  all models; use empty list for no model access.
                 items:
                   type: string
                 type: array
@@ -369,7 +370,8 @@ spec:
                 description: MaxParallelRequests limits concurrent requests
                 type: integer
               models:
-                description: Models specifies which models can be used
+                description: Models specifies which models can be used. Omit to allow
+                  all models; use empty list for no model access.
                 items:
                   type: string
                 type: array

--- a/docs/api-reference/auth.litellm.ai.md
+++ b/docs/api-reference/auth.litellm.ai.md
@@ -389,7 +389,7 @@ _Appears in:_
 | `modelMaxBudget` _object (keys:string, values:string)_ | ModelMaxBudget is the model specific maximum budget |  |  |
 | `modelRPMLimit` _object (keys:string, values:string)_ | ModelRPMLimit is the model specific maximum requests per minute |  |  |
 | `modelTPMLimit` _object (keys:string, values:string)_ | ModelTPMLimit is the model specific maximum tokens per minute |  |  |
-| `models` _string array_ | Models is the list of models that the user is allowed to use |  |  |
+| `models` _string array_ | Models the user is allowed to use. Omit to allow all models; use empty list for no model access. |  |  |
 | `permissions` _object (keys:string, values:string)_ | Permissions is the user-specific permissions |  |  |
 | `rpmLimit` _integer_ | RPMLimit is the maximum requests per minute for the user |  |  |
 | `sendInviteEmail` _boolean_ | SendInviteEmail is whether to send an invite email to the user - NOTE: the user endpoint will return an error if email alerting is not configured and this is enabled, but the user will still be created. |  |  |
@@ -439,7 +439,7 @@ _Appears in:_
 | `modelMaxBudget` _object (keys:string, values:string)_ | ModelMaxBudget is the model specific maximum budget |  |  |
 | `modelRPMLimit` _object (keys:string, values:string)_ | ModelRPMLimit is the model specific maximum requests per minute |  |  |
 | `modelTPMLimit` _object (keys:string, values:string)_ | ModelTPMLimit is the model specific maximum tokens per minute |  |  |
-| `models` _string array_ | Models is the list of models that the user is allowed to use |  |  |
+| `models` _string array_ | Models the user is allowed to use. Omit to allow all models; use empty list for no model access. |  |  |
 | `permissions` _object (keys:string, values:string)_ | Permissions is the user-specific permissions |  |  |
 | `rpmLimit` _integer_ | RPMLimit is the maximum requests per minute |  |  |
 | `spend` _string_ | Spend is the amount spent by user |  |  |
@@ -531,7 +531,7 @@ _Appears in:_
 | `modelMaxBudget` _object (keys:string, values:string)_ | ModelMaxBudget sets budget limits per model |  |  |
 | `modelRPMLimit` _object (keys:string, values:integer)_ | ModelRPMLimit sets RPM limits per model |  |  |
 | `modelTPMLimit` _object (keys:string, values:integer)_ | ModelTPMLimit sets TPM limits per model |  |  |
-| `models` _string array_ | Models specifies which models can be used |  |  |
+| `models` _string array_ | Models the key can use. Omit to allow all models; use empty list for no model access. |  |  |
 | `permissions` _object (keys:string, values:string)_ | Permissions defines key permissions |  |  |
 | `rpmLimit` _integer_ | RPMLimit sets global RPM limit |  |  |
 | `sendInviteEmail` _boolean_ | SendInviteEmail indicates whether to send an invite email |  |  |
@@ -577,7 +577,7 @@ _Appears in:_
 | `liteLLMBudgetTable` _string_ | LiteLLMBudgetTable is the budget table reference |  |  |
 | `maxBudget` _string_ | MaxBudget is the maximum budget for the key |  |  |
 | `maxParallelRequests` _integer_ | MaxParallelRequests limits concurrent requests |  |  |
-| `models` _string array_ | Models specifies which models can be used |  |  |
+| `models` _string array_ | Models the key can use. Omit to allow all models; use empty list for no model access. |  |  |
 | `permissions` _object (keys:string, values:string)_ | Permissions defines key permissions |  |  |
 | `rpmLimit` _integer_ | RPMLimit sets global RPM limit |  |  |
 | `spend` _string_ | Spend tracks the current spend amount |  |  |

--- a/docs/user-guide/users.md
+++ b/docs/user-guide/users.md
@@ -14,7 +14,56 @@ User resources in the LiteLLM Operator provide:
 
 ## Creating Users
 
-### Basic User
+### Basic User (All Models)
+
+Omit the `models` field to allow the user access to all models:
+
+```yaml
+apiVersion: auth.litellm.ai/v1alpha1
+kind: User
+metadata:
+  name: alice
+spec:
+  userEmail: "alice@example.com"
+  userAlias: "alice"
+  userRole: "internal_user_viewer"
+  keyAlias: "alice-key"
+  autoCreateKey: true
+  maxBudget: "10"
+  budgetDuration: 1h
+  connectionRef:
+    instanceRef:
+      name: litellm-example
+      namespace: litellm
+```
+
+### User with No Model Access
+
+Set `models: []` to restrict the user to no models (no model access):
+
+```yaml
+apiVersion: auth.litellm.ai/v1alpha1
+kind: User
+metadata:
+  name: restricted-user
+spec:
+  userEmail: "restricted@example.com"
+  userAlias: "restricted"
+  userRole: "internal_user_viewer"
+  keyAlias: "restricted-key"
+  autoCreateKey: true
+  models: []
+  maxBudget: "10"
+  budgetDuration: 1h
+  connectionRef:
+    instanceRef:
+      name: litellm-example
+      namespace: litellm
+```
+
+### User with Specific Models
+
+Specify a list to restrict the user to certain models only:
 
 ```yaml
 apiVersion: auth.litellm.ai/v1alpha1
@@ -70,7 +119,7 @@ spec:
 | `userRole` | string | User role (one of "proxy_admin", "proxy_admin_viewer", "internal_user", "internal_user_viewer") | Yes |
 | `keyAlias` | string | Alias for the virtual key | No |
 | `autoCreateKey` | boolean | Automatically create virtual key | Yes |
-| `models` | []string | Allowed models for this user | No |
+| `models` | []string | Allowed models. **Omit** this field to allow **all models**. Set `models: []` to restrict the user to no models. Specify a list to restrict the user to those models only. | No |
 | `maxBudget` | string | Maximum spend limit in dollars | Yes |
 | `budgetDuration` | string | Budget duration (e.g., "1h", "30d") | Yes |
 | `connectionRef` | object | Reference to LiteLLM instance | Yes |

--- a/docs/user-guide/virtual-keys.md
+++ b/docs/user-guide/virtual-keys.md
@@ -13,7 +13,48 @@ Virtual Keys in the LiteLLM Operator provide:
 
 ## Creating Virtual Keys
 
-### Basic Virtual Key
+### Virtual Key with All Models
+
+Omit the `models` field to allow access to all models:
+
+```yaml
+apiVersion: auth.litellm.ai/v1alpha1
+kind: VirtualKey
+metadata:
+  name: example-service
+spec:
+  keyAlias: example-service
+  maxBudget: "10"
+  budgetDuration: 1h
+  connectionRef:
+    instanceRef:
+      name: litellm-example
+      namespace: litellm
+```
+
+### Virtual Key with No Model Access
+
+Set `models: []` to restrict the key to no models (no model access):
+
+```yaml
+apiVersion: auth.litellm.ai/v1alpha1
+kind: VirtualKey
+metadata:
+  name: restricted-key
+spec:
+  keyAlias: restricted-key
+  models: []
+  maxBudget: "10"
+  budgetDuration: 1h
+  connectionRef:
+    instanceRef:
+      name: litellm-example
+      namespace: litellm
+```
+
+### Virtual Key with Specific Models
+
+Specify a list to restrict the key to certain models only:
 
 ```yaml
 apiVersion: auth.litellm.ai/v1alpha1
@@ -58,7 +99,7 @@ spec:
 | Field | Type | Description | Required |
 |-------|------|-------------|----------|
 | `keyAlias` | string | Unique identifier for the key | Yes |
-| `models` | []string | Allowed models (empty = all models) | No |
+| `models` | []string | Allowed models. **Omit** this field to allow **all models**. Set `models: []` to restrict the key to no models. Specify a list to restrict the key to those models only. | No |
 | `maxBudget` | string | Maximum spend limit in dollars | Yes |
 | `budgetDuration` | string | Budget duration (e.g., "1h", "30d") | Yes |
 | `connectionRef` | object | Reference to LiteLLM instance | Yes |

--- a/internal/controller/user/user_controller.go
+++ b/internal/controller/user/user_controller.go
@@ -330,7 +330,6 @@ func (r *UserReconciler) convertToUserRequest(user *authv1alpha1.User) (litellm.
 		ModelMaxBudget:       user.Spec.ModelMaxBudget,
 		ModelRPMLimit:        user.Spec.ModelRPMLimit,
 		ModelTPMLimit:        user.Spec.ModelTPMLimit,
-		Models:               user.Spec.Models,
 		Permissions:          user.Spec.Permissions,
 		RPMLimit:             user.Spec.RPMLimit,
 		SendInviteEmail:      user.Spec.SendInviteEmail,
@@ -341,6 +340,12 @@ func (r *UserReconciler) convertToUserRequest(user *authv1alpha1.User) (litellm.
 		UserEmail:            user.Spec.UserEmail,
 		UserID:               user.Spec.UserID,
 		UserRole:             user.Spec.UserRole,
+	}
+
+	// Omit (models not set) → do not send "models" to API → LiteLLM allows all models.
+	// Explicit empty list (models: []) → send "models": [] → user has no model access.
+	if user.Spec.Models != nil {
+		userRequest.Models = user.Spec.Models
 	}
 
 	if user.Spec.MaxBudget != "" {

--- a/internal/controller/user/user_controller.go
+++ b/internal/controller/user/user_controller.go
@@ -344,8 +344,11 @@ func (r *UserReconciler) convertToUserRequest(user *authv1alpha1.User) (litellm.
 
 	// Omit (models not set) → do not send "models" to API → LiteLLM allows all models.
 	// Explicit empty list (models: []) → send "models": [] → user has no model access.
+	// Copy slice so the request does not share memory with Spec (callers may mutate Spec later).
 	if user.Spec.Models != nil {
-		userRequest.Models = user.Spec.Models
+		modelsCopy := make([]string, len(user.Spec.Models))
+		copy(modelsCopy, user.Spec.Models)
+		userRequest.Models = &modelsCopy
 	}
 
 	if user.Spec.MaxBudget != "" {

--- a/internal/controller/virtualkey/virtualkey_controller.go
+++ b/internal/controller/virtualkey/virtualkey_controller.go
@@ -378,7 +378,6 @@ func (r *VirtualKeyReconciler) convertToVirtualKeyRequest(virtualKey *authv1alph
 		ModelMaxBudget:       virtualKey.Spec.ModelMaxBudget,
 		ModelRPMLimit:        virtualKey.Spec.ModelRPMLimit,
 		ModelTPMLimit:        virtualKey.Spec.ModelTPMLimit,
-		Models:               virtualKey.Spec.Models,
 		Permissions:          virtualKey.Spec.Permissions,
 		RPMLimit:             virtualKey.Spec.RPMLimit,
 		SendInviteEmail:      virtualKey.Spec.SendInviteEmail,
@@ -386,6 +385,12 @@ func (r *VirtualKeyReconciler) convertToVirtualKeyRequest(virtualKey *authv1alph
 		TeamID:               virtualKey.Spec.TeamID,
 		TPMLimit:             virtualKey.Spec.TPMLimit,
 		UserID:               virtualKey.Spec.UserID,
+	}
+
+	// Omit (field not set) → do not set request.Models (nil) → API omits "models" → all models allowed.
+	// Explicit empty list (models: []) → set request.Models = [] → API sends "models": [] → no model access.
+	if virtualKey.Spec.Models != nil {
+		virtualKeyRequest.Models = virtualKey.Spec.Models
 	}
 
 	if virtualKey.Spec.MaxBudget != "" {

--- a/internal/controller/virtualkey/virtualkey_controller.go
+++ b/internal/controller/virtualkey/virtualkey_controller.go
@@ -389,8 +389,11 @@ func (r *VirtualKeyReconciler) convertToVirtualKeyRequest(virtualKey *authv1alph
 
 	// Omit (field not set) → do not set request.Models (nil) → API omits "models" → all models allowed.
 	// Explicit empty list (models: []) → set request.Models = [] → API sends "models": [] → no model access.
+	// Copy slice so the request does not share memory with Spec (callers may mutate Spec later).
 	if virtualKey.Spec.Models != nil {
-		virtualKeyRequest.Models = virtualKey.Spec.Models
+		modelsCopy := make([]string, len(virtualKey.Spec.Models))
+		copy(modelsCopy, virtualKey.Spec.Models)
+		virtualKeyRequest.Models = &modelsCopy
 	}
 
 	if virtualKey.Spec.MaxBudget != "" {

--- a/internal/controller/virtualkey/virtualkey_controller_test.go
+++ b/internal/controller/virtualkey/virtualkey_controller_test.go
@@ -543,14 +543,15 @@ var _ = Describe("VirtualKey Controller", func() {
 			request, err := reconciler.convertToVirtualKeyRequest(virtualKey)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(request.Models).NotTo(BeNil())
-			Expect(request.Models).To(HaveLen(0))
+			Expect(*request.Models).To(HaveLen(0))
 		})
 
 		It("models list set → same list in request", func() {
 			virtualKey.Spec.Models = []string{"gpt-4", "gpt-3.5-turbo"}
 			request, err := reconciler.convertToVirtualKeyRequest(virtualKey)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(request.Models).To(Equal([]string{"gpt-4", "gpt-3.5-turbo"}))
+			Expect(request.Models).NotTo(BeNil())
+			Expect(*request.Models).To(Equal([]string{"gpt-4", "gpt-3.5-turbo"}))
 		})
 
 		It("all three models cases produce different results", func() {
@@ -565,13 +566,14 @@ var _ = Describe("VirtualKey Controller", func() {
 			reqEmpty, err := reconciler.convertToVirtualKeyRequest(virtualKey)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(reqEmpty.Models).NotTo(BeNil())
-			Expect(reqEmpty.Models).To(HaveLen(0))
+			Expect(*reqEmpty.Models).To(HaveLen(0))
 
 			// Non-empty list: request.Models must be the same slice
 			virtualKey.Spec.Models = []string{"gpt-4"}
 			reqList, err := reconciler.convertToVirtualKeyRequest(virtualKey)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(reqList.Models).To(Equal([]string{"gpt-4"}))
+			Expect(reqList.Models).NotTo(BeNil())
+			Expect(*reqList.Models).To(Equal([]string{"gpt-4"}))
 
 			// All three outcomes must differ: nil vs [] vs [gpt-4]
 			Expect(reqOmit.Models).NotTo(Equal(reqEmpty.Models))

--- a/internal/litellm/litellm_user.go
+++ b/internal/litellm/litellm_user.go
@@ -37,7 +37,7 @@ type UserRequest struct {
 	ModelMaxBudget       map[string]string `json:"model_max_budget,omitempty"`
 	ModelRPMLimit        map[string]string `json:"model_rpm_limit,omitempty"`
 	ModelTPMLimit        map[string]string `json:"model_tpm_limit,omitempty"`
-	Models               []string          `json:"models"`
+	Models               *[]string         `json:"models,omitempty"`
 	Permissions          map[string]string `json:"permissions,omitempty"`
 	RPMLimit             int               `json:"rpm_limit,omitempty"`
 	SendInviteEmail      bool              `json:"send_invite_email,omitempty"`
@@ -269,7 +269,12 @@ func (l *LitellmClient) IsUserUpdateNeeded(ctx context.Context, user *UserRespon
 	checkField("guardrails", "Guardrails", user.Guardrails, req.Guardrails, true, true)
 	checkField("max_budget", "MaxBudget", user.MaxBudget, req.MaxBudget, false, false)
 	checkField("max_parallel_requests", "MaxParallelRequests", user.MaxParallelRequests, req.MaxParallelRequests, false, true)
-	checkField("models", "Models", user.Models, req.Models, true, false)
+	// Use reflect.DeepEqual for Models so nil ("all models") and [] ("no model access") are distinguished.
+	var reqModels []string
+	if req.Models != nil {
+		reqModels = *req.Models
+	}
+	checkField("models", "Models", user.Models, reqModels, false, false)
 	checkField("permissions", "Permissions", user.Permissions, req.Permissions, true, false)
 	checkField("rpm_limit", "RPMLimit", user.RPMLimit, req.RPMLimit, false, true)
 	checkField("send_invite_email", "SendInviteEmail", user.SendInviteEmail, req.SendInviteEmail, false, true)

--- a/internal/litellm/litellm_user.go
+++ b/internal/litellm/litellm_user.go
@@ -37,7 +37,7 @@ type UserRequest struct {
 	ModelMaxBudget       map[string]string `json:"model_max_budget,omitempty"`
 	ModelRPMLimit        map[string]string `json:"model_rpm_limit,omitempty"`
 	ModelTPMLimit        map[string]string `json:"model_tpm_limit,omitempty"`
-	Models               []string          `json:"models,omitempty"`
+	Models               []string          `json:"models"`
 	Permissions          map[string]string `json:"permissions,omitempty"`
 	RPMLimit             int               `json:"rpm_limit,omitempty"`
 	SendInviteEmail      bool              `json:"send_invite_email,omitempty"`

--- a/internal/litellm/litellm_virtualkey.go
+++ b/internal/litellm/litellm_virtualkey.go
@@ -39,7 +39,7 @@ type VirtualKeyRequest struct {
 	ModelMaxBudget       map[string]string `json:"model_max_budget,omitempty"`
 	ModelRPMLimit        map[string]int    `json:"model_rpm_limit,omitempty"`
 	ModelTPMLimit        map[string]int    `json:"model_tpm_limit,omitempty"`
-	Models               []string          `json:"models"`
+	Models               *[]string         `json:"models,omitempty"`
 	Permissions          map[string]string `json:"permissions,omitempty"`
 	RPMLimit             int               `json:"rpm_limit,omitempty"`
 	SendInviteEmail      bool              `json:"send_invite_email,omitempty"`
@@ -297,7 +297,12 @@ func (l *LitellmClient) IsVirtualKeyUpdateNeeded(ctx context.Context, virtualKey
 		log.Info("MaxParallelRequests changed")
 		return true
 	}
-	if !cmp.Equal(virtualKey.Models, req.Models, cmpopts.EquateEmpty()) {
+	// Compare Models without EquateEmpty so nil ("all models") and [] ("no models") are distinguished.
+	var reqModels []string
+	if req.Models != nil {
+		reqModels = *req.Models
+	}
+	if !cmp.Equal(virtualKey.Models, reqModels) {
 		log.Info("Models changed")
 		return true
 	}

--- a/internal/litellm/litellm_virtualkey.go
+++ b/internal/litellm/litellm_virtualkey.go
@@ -39,7 +39,7 @@ type VirtualKeyRequest struct {
 	ModelMaxBudget       map[string]string `json:"model_max_budget,omitempty"`
 	ModelRPMLimit        map[string]int    `json:"model_rpm_limit,omitempty"`
 	ModelTPMLimit        map[string]int    `json:"model_tpm_limit,omitempty"`
-	Models               []string          `json:"models,omitempty"`
+	Models               []string          `json:"models"`
 	Permissions          map[string]string `json:"permissions,omitempty"`
 	RPMLimit             int               `json:"rpm_limit,omitempty"`
 	SendInviteEmail      bool              `json:"send_invite_email,omitempty"`


### PR DESCRIPTION
**What type of PR is this?**  /kind enhancement 

# feat: models field — omit = all models, empty list = no model access

## Summary

Makes the `models` field behaviour explicit and consistent for **VirtualKey** and **User**:

- **Omit** (field not set in spec) → **All models** allowed. The operator does not send `models` to the LiteLLM API, so the key/user has access to all models.
- **Explicit empty list** (`models: []`) → **No model access**. The operator sends `"models": []` to the API, so the key/user cannot use any model.
- **Non-empty list** (`models: [gpt-4, ...]`) → Key/user is restricted to the listed models only.

Previously, both “omit” and “empty list” were effectively treated the same (no `models` sent), so keys/users with `models: []` unexpectedly had access to all models.

## Changes

### VirtualKey

- **Controller** (`internal/controller/virtualkey/virtualkey_controller.go`): Set `request.Models` only when `Spec.Models != nil`. So `nil` (omit) → not set → all models; `[]` → sent as `[]` → no models.
- **Tests** (`internal/controller/virtualkey/virtualkey_controller_test.go`): Added/updated tests for:
  - omitted `models` → `request.Models` is `nil`
  - `models: []` → `request.Models` is non-nil empty slice
  - `models: [gpt-4, ...]` → `request.Models` equals the list
  - One test that asserts all three cases produce different results.

### User

- **Controller** (`internal/controller/user/user_controller.go`): Same logic: set `request.Models` only when `user.Spec.Models != nil`.

### API types & docs

- **Types** (`api/auth/v1alpha1/virtualkey_types.go`, `api/auth/v1alpha1/user_types.go`): Comment for `Models` updated to: “Omit to allow all models; use empty list for no model access.”
- **User guide**: `docs/user-guide/virtual-keys.md`, `docs/user-guide/users.md` — clarified `models` behaviour, added examples for “no model access” (`models: []`), updated spec tables.
- **API reference**: `docs/api-reference/auth.litellm.ai.md` — aligned `models` descriptions for VirtualKey and User.

## Examples

**VirtualKey — all models (omit):**
```yaml
spec:
  keyAlias: my-key
  # models not set → all models
  maxBudget: "10"
  budgetDuration: 1d
  connectionRef: ...
```

**VirtualKey — no model access:**
```yaml
spec:
  keyAlias: restricted-key
  models: []
  maxBudget: "10"
  budgetDuration: 1d
  connectionRef: ...
```

**User** — same rules: omit `models` for all models, set `models: []` for no model access.

## Testing

- `go test ./internal/controller/virtualkey/...` — unit tests for `convertToVirtualKeyRequest` (omit, empty list, list, and “all three differ”).
- `go test ./...` — full test suite.

## Checklist

- [x] Logic: omit → all models, `models: []` → no models (VirtualKey + User).
- [x] Unit tests for VirtualKey covering all three cases and different outcomes.
- [x] Docs and API comments updated (user guide, API reference, type comments).
