### PR TITLE
feat: adds support for topology spread constraints

### DIFF
--- a/deploy/charts/litellm-operator/templates/deployment.yaml
+++ b/deploy/charts/litellm-operator/templates/deployment.yaml
@@ -53,3 +53,7 @@ spec:
         8 }}
       serviceAccountName: {{ include "litellm-operator.fullname" . }}-controller-manager
       terminationGracePeriodSeconds: 10
+      {{- with .Values.controllerManager.topologySpreadConstraints }}
+      topologySpreadConstraints:
+          {{- toYaml . | nindent 8  }}
+      {{- end}}

--- a/deploy/charts/litellm-operator/values.schema.json
+++ b/deploy/charts/litellm-operator/values.schema.json
@@ -119,6 +119,112 @@
             }
           }
         },
+        "topologySpreadConstraints": {
+          "type": "array",
+          "description": "Pod topology spread constraints",
+          "items": {
+            "type": "object",
+            "properties": {
+              "maxSkew": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Maximum permitted difference between topology domains"
+              },
+              "topologyKey": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Node label key that defines topology domain"
+              },
+              "whenUnsatisfiable": {
+                "type": "string",
+                "enum": [
+                  "DoNotSchedule",
+                  "ScheduleAnyway"
+                ],
+                "description": "How to handle unsatisfied constraint"
+              },
+              "labelSelector": {
+                "type": "object",
+                "description": "Label selector to identify pods",
+                "properties": {
+                  "matchLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "matchExpressions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "key",
+                        "operator"
+                      ],
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "operator": {
+                          "type": "string",
+                          "enum": [
+                            "In",
+                            "NotIn",
+                            "Exists",
+                            "DoesNotExist"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "minDomains": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Minimum number of topology domains required (optional)"
+              },
+              "nodeAffinityPolicy": {
+                "type": "string",
+                "enum": [
+                  "Honor",
+                  "Ignore"
+                ],
+                "description": "Node affinity policy (beta since K8s 1.26+)"
+              },
+              "nodeTaintsPolicy": {
+                "type": "string",
+                "enum": [
+                  "Honor",
+                  "Ignore"
+                ],
+                "description": "Node taints policy (beta K8s 1.26+)"
+              },
+              "matchLabelKeys": {
+                "type": "array",
+                "description": "List of pod label keys to match for topology spread",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "maxSkew",
+              "topologyKey",
+              "whenUnsatisfiable",
+              "labelSelector"
+            ]
+          }
+        },
         "podSecurityContext": {
           "type": "object",
           "description": "Pod security context configuration",

--- a/deploy/charts/litellm-operator/values.yaml
+++ b/deploy/charts/litellm-operator/values.yaml
@@ -22,6 +22,7 @@ controllerManager:
       requests:
         cpu: 50m
         memory: 64Mi
+  topologySpreadConstraints: []
   podSecurityContext:
     runAsNonRoot: true
   replicas: 1


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

/kind enhancement 

**What does this PR do / why we need it**:
This PR adds support for setting pod topology spread constraints, this optional configuration improves high availability by enabling operator pods to be scheduled across failure domains. 

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
