### PR TITLE
chore: Remove gomod updates from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,24 +1,12 @@
 version: 2
 updates:
-  # Enable version updates for Go modules
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-    open-pull-requests-limit: 5
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "09:00"
+      time: "07:00"
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore"
@@ -30,7 +18,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "09:00"
+      time: "07:00"
     open-pull-requests-limit: 3
     commit-message:
       prefix: "chore"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bbdsoftware/litellm-operator
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/scripts/local-dev/Makefile
+++ b/scripts/local-dev/Makefile
@@ -64,3 +64,7 @@ vind-get-loadbalancer-ip: ## Get the IP address of the load balancer service.
 .PHONY: debug-port-forward-litellm
 debug-port-forward-litellm: ## Port forward the litellm example service for a debug session of the operator.
 	$(KUBECTL) port-forward svc/litellm-example-service 4000:4000 -n litellm
+
+.PHONY: vind-get-admin-password
+vind-get-admin-password: ## Get the admin password for the litellm example service.
+	$(KUBECTL) get secret litellm-example-secrets -n litellm -o jsonpath='{.data.masterkey}' | base64 -d


### PR DESCRIPTION
**What type of PR is this?**

/kind chore

**What does this PR do / why we need it**:

Remove gomod updates from dependabot as it's very noisy and we have govulncheck to cover this