### PR TITLE
feat(model): support mode param

### DIFF
--- a/api/litellm/v1alpha1/model_types.go
+++ b/api/litellm/v1alpha1/model_types.go
@@ -183,6 +183,9 @@ type ModelInfo struct {
 	// TeamPublicModelName is the team public model name
 	TeamPublicModelName *string `json:"teamPublicModelName,omitempty"`
 
+	// Mode is the mode of the model
+	Mode *string `json:"mode,omitempty"`
+
 	// AdditionalProps contains additional properties
 	AdditionalProps *runtime.RawExtension `json:"additionalProp1,omitempty"`
 }

--- a/api/litellm/v1alpha1/zz_generated.deepcopy.go
+++ b/api/litellm/v1alpha1/zz_generated.deepcopy.go
@@ -562,6 +562,11 @@ func (in *ModelInfo) DeepCopyInto(out *ModelInfo) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Mode != nil {
+		in, out := &in.Mode, &out.Mode
+		*out = new(string)
+		**out = **in
+	}
 	if in.AdditionalProps != nil {
 		in, out := &in.AdditionalProps, &out.AdditionalProps
 		*out = new(runtime.RawExtension)

--- a/config/crd/bases/litellm.litellm.ai_models.yaml
+++ b/config/crd/bases/litellm.litellm.ai_models.yaml
@@ -232,6 +232,9 @@ spec:
                   id:
                     description: ID is the model ID
                     type: string
+                  mode:
+                    description: Mode is the mode of the model
+                    type: string
                   teamId:
                     description: TeamID is the team ID
                     type: string

--- a/internal/controller/model/model_controller.go
+++ b/internal/controller/model/model_controller.go
@@ -465,6 +465,9 @@ func (r *ModelReconciler) convertToModelRequest(ctx context.Context, model *lite
 		}
 		modelRequest.LiteLLMParams = litellmParams
 		modelRequest.ModelInfo = litellm.NewModelInfo()
+		if model.Spec.ModelInfo.Mode != nil && *model.Spec.ModelInfo.Mode != "" {
+			modelRequest.ModelInfo.Mode = model.Spec.ModelInfo.Mode
+		}
 		if model.Status.ModelId != nil && *model.Status.ModelId != "" {
 			modelRequest.ModelInfo.ID = model.Status.ModelId
 		}

--- a/internal/litellm/litellm_model.go
+++ b/internal/litellm/litellm_model.go
@@ -89,6 +89,7 @@ type ModelInfo struct {
 	DBModel              *bool                  `json:"db_model,omitempty"`
 	TeamID               *string                `json:"team_id,omitempty"`
 	TeamPublicModelName  *string                `json:"team_public_model_name,omitempty"`
+	Mode                 *string                `json:"mode,omitempty"`
 	AdditionalProperties map[string]interface{} `json:"-"`
 }
 
@@ -301,6 +302,7 @@ func (l *LitellmClient) IsModelUpdateNeeded(ctx context.Context, model *ModelRes
 		checkField("model_info_id", "Model info ID", model.ModelInfo.ID, req.ModelInfo.ID, true, true)
 		checkField("team_id", "Team ID", model.ModelInfo.TeamID, req.ModelInfo.TeamID, true, true)
 		checkField("team_public_model_name", "Team public model name", model.ModelInfo.TeamPublicModelName, req.ModelInfo.TeamPublicModelName, true, true)
+		checkField("mode", "Mode", model.ModelInfo.Mode, req.ModelInfo.Mode, true, true)
 	}
 
 	if changedFields.NeedsUpdate {


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:

Adds support for the `mode` parameter in the Model CRD's `modelInfo` section. LiteLLM uses the mode setting (e.g. `chat`, `embedding`, `completion`) to indicate what type of endpoint a model serves and how health checks should call it. Until now the operator had no way to set it declaratively.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**How to test changes / Special notes to the reviewer**:

Apply a `Model` resource with `spec.modelInfo.mode` set (e.g. `mode: embedding`) and verify the CRD accepts it and the value is passed through to LiteLLM's model info. The field is optional, so existing Model resources are unaffected.